### PR TITLE
OAuth login(security, oauth2, jwt)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
 
     // LOG : Response Body
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.300'
+
+    //OAuth, Authentication
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bucwith/common/CommController.java
+++ b/src/main/java/com/bucwith/common/CommController.java
@@ -4,7 +4,7 @@ import com.bucwith.common.code.ApiCode;
 import com.bucwith.dto.ResponseDto;
 import org.springframework.http.ResponseEntity;
 
-public class CommController {
+public class CommController  {
 
     public ResponseEntity SuccessReturn(Object data) {
         return ResponseEntity.ok().body(

--- a/src/main/java/com/bucwith/common/code/ApiCode.java
+++ b/src/main/java/com/bucwith/common/code/ApiCode.java
@@ -11,9 +11,15 @@ public enum ApiCode {
     DB_FAIL(301, "DB ERROR"),
     NOT_FOUND_DATA(302, "DB NOT_FOUND_DATA"),
 
+    EMPTY_JWT(2001, "JWT를 입력해주세요."),
+    INVALID_JWT( 2002, "유효하지 않은 JWT입니다."),
+    INVALID_USER_JWT(2003,"권한이 없는 유저의 접근입니다."),
+
     // ------------------------FUNCTION----------------------------
     
     UNKNOWN_ERROR(1000, "알수 없는 오류");
+
+
 
 
     private int code;

--- a/src/main/java/com/bucwith/common/config/SecurityConfig.java
+++ b/src/main/java/com/bucwith/common/config/SecurityConfig.java
@@ -1,0 +1,100 @@
+package com.bucwith.common.config;
+
+import com.bucwith.common.config.oauth.ConfigSuccessHandler;
+import com.bucwith.common.config.oauth.CustomOAuth2UserService;
+import com.bucwith.common.config.oauth.JwtAuthenticationFilter;
+import com.bucwith.domain.account.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private final CustomOAuth2UserService customOAuth2UserService;
+    @Autowired
+    private final JwtService jwtService;
+    @Autowired
+    private final ConfigSuccessHandler successHandler;
+
+
+    /** Spring Security
+     *
+     * Security 설정
+     * /login/**에서 모든 권한 허용
+     * 나머지는 인가된 사용자에게만
+     *
+     * jwt 토큰을 받아 필터 수행
+     *
+     * OAuth2 로그인 성공시 CustomOAuth2Service로 이동
+
+     **/
+    @Override
+    protected void configure(HttpSecurity http) throws Exception{
+        http
+                //csrf 공격을 막아주는 옵션을 disalbe, rest api같은 경우에는 브라우저를 통해 request 받지 않기 때문에 해당 옵션을 꺼도 됨
+                .csrf().disable()
+                .headers().frameOptions().disable()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 스프링 시큐리티가 세션 쿠키 방식으로 동작하지 않도록 설정
+                .and()
+
+                // authorizeRequests
+                // URL별 권한 관리를 설정하는 옵션의 시작점이다. authorizeRequests가 선언되어야만 antMatchers 옵션을 사용할 수 있다.
+                .authorizeRequests()
+
+                // antMatchers
+                // 권한 관리 대상을 지정하는 옵션이다.
+                // URL, HTTP 메소드별로 관리가 가능하다. 지정된 URL들은 permitAll() 옵션을 통해 전체 열람 관한을 준다.
+                .antMatchers("/", "/login/**").permitAll()
+                .antMatchers("/oauth2/**", "/auth/**").permitAll()
+
+                // anyRequest
+                // 설정된 값 이외의 나머지 URL들을 나타낸다. authenticated()를 추가하여 나머지 URL들은 모두 인증된 사용자들(로그인한 사용자들)에게만 허용한다.
+                .anyRequest().authenticated()
+                .and()
+
+                // 로그아웃 기능에 대한 여러 설정의 진입점이다. 로그아웃 성공시 "/" 주소로 이동한다.
+                .logout()
+                .logoutSuccessUrl("/")
+                .and()
+
+                // oauth2Login
+                // OAuth 2 로그인 기능에 대한 여러 설정의 진입점이다.
+                .oauth2Login()
+                /*.loginPage("/oauth2Login")
+                .redirectionEndpoint()
+                .baseUri("/oauth2/callback/*") // 디폴트는 login/oauth2/code/*
+                .and()*/
+                //.defaultSuccessUrl("/oauth2/loginInfo", true) //OAuth2 성공시 redirect
+
+                // userInfoEndpoint
+                // OAuth 2 로그인 성공 이후 사용자 정보를 가져올 떄의 설정들을 담당한다.
+                .userInfoEndpoint()
+
+                // userService
+                // 소셜 로그인 성공시 후속 조치를 진행할 UserService 인터페이스의 구현체를 등록한다.
+                // 리소스 서버(소셜 서비스들)에서 사용자 정보를 가져온 상태에서 추가로 진행하고자하는 기능을 명시할 수 있다.
+                .userService(customOAuth2UserService)
+                .and()
+                //성공시 토큰반환해주는 handler
+                .successHandler(successHandler);
+                //.failureHandler(configFailureHandler())
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
+
+    }
+
+
+
+}

--- a/src/main/java/com/bucwith/common/config/oauth/ConfigSuccessHandler.java
+++ b/src/main/java/com/bucwith/common/config/oauth/ConfigSuccessHandler.java
@@ -1,0 +1,65 @@
+package com.bucwith.common.config.oauth;
+
+import com.bucwith.common.config.JwtService;
+import com.bucwith.common.config.oauth.dto.OAuthAttributes;
+import com.bucwith.common.config.oauth.dto.OAuthToken;
+import com.bucwith.dto.user.UserDto;
+import com.bucwith.mapper.user.UserRequestMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.bucwith.domain.account.Role.USER;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ConfigSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtService jwtService;
+    private final UserRequestMapper userRequestMapper;
+
+    /**
+     * success handler
+     * oauth 로그인 성공했을시 토큰 발행
+     */
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+
+        OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+        UserDto userDto = userRequestMapper.toDto(oAuth2User);
+
+        log.info("Principal에서 꺼낸 OAuth2User = {}", oAuth2User);
+        // 최초 로그인이라면 회원가입 처리를 한다.
+        String targetUrl;
+        log.info("토큰 발행 시작");
+        OAuthToken token = jwtService.createJwt(userDto.getEmail(), USER);
+        log.info("{}", token);
+        /* 로그인 뒤 redirect처리*/
+        /*targetUrl = UriComponentsBuilder.fromUriString("/user/name")
+                .queryParam("token", "token")
+                .build().toUriString();
+        //getRedirectStrategy().sendRedirect(request, response, targetUrl);*/
+    }
+
+
+}

--- a/src/main/java/com/bucwith/common/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/bucwith/common/config/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,87 @@
+package com.bucwith.common.config.oauth;
+
+import com.bucwith.common.config.JwtService;
+import com.bucwith.common.config.oauth.dto.OAuthAttributes;
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.account.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+
+/**
+ * OAuth Login을 통해 들어온 값들을 처리
+ *
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final HttpSession httpSession;
+
+
+    /**
+     * OAuth2UserRequest로 들어온 userRequest값들을 db에 저장
+     *
+     * @param userRequest the user request
+     * @return
+     * @throws OAuth2AuthenticationException
+     */
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest); // OAuth 서비스(kakao, google, naver)에서 가져온 유저 정보를 담고있음
+
+        // registrationId
+        // 햔재 로그인 진행 중인 서비스를 구분하는 코드
+        // 네이버 로그인인지, 구글 로그인인지 구분하기위해 사용
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // userNameAttributeName
+        // OAuth2 로그인 진행 시 키가 되는 필드값을 말한다. PK와 같은 의미이다.
+        // 구글의 경우 기본적으로 코드를 지원한다. 구글의 기본 코드는 "sub"이다. (네이버, 카카오 등은 기본 지원하지 않음)
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        // OAuthAttributes
+        // OAuth2UserService를 통해 가져온 OAuth2User의 attributes를 담을 클래스이다.
+        // 다른 소셜 로그인도 이 클래스를 사용한다.
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        log.info("{}", attributes);
+
+        User user = saveOrUpdate(attributes);
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+
+
+
+    /**
+     * loadUser함수에서 user객체 저장하는 함수
+     *
+     * @param attributes
+     * @return
+     */
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName()))
+                .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/bucwith/common/config/oauth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bucwith/common/config/oauth/JwtAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package com.bucwith.common.config.oauth;
+
+import com.bucwith.common.config.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+/**
+ * SecurityConfig 에서 사용하는 jwt filter 클래스
+ */
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    @Autowired
+    private JwtService jwtService;
+
+    public JwtAuthenticationFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    // Request로 들어오는 Jwt Token의 유효성을 검증하는 filter를 filterChain에 등록합니다.
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        String token = jwtService.getJwt();
+        if (token != null && jwtService.validateToken(token)) {   // token 검증
+            Authentication auth = jwtService.getAuthentication(token);    // 인증 객체 생성
+            SecurityContextHolder.getContext().setAuthentication(auth); // SecurityContextHolder에 인증 객체 저장
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/src/main/java/com/bucwith/common/config/oauth/dto/OAuthAttributes.java
+++ b/src/main/java/com/bucwith/common/config/oauth/dto/OAuthAttributes.java
@@ -1,0 +1,54 @@
+package com.bucwith.common.config.oauth.dto;
+
+import com.bucwith.domain.account.Role;
+import com.bucwith.domain.account.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+
+    }
+
+    // of()
+    // OAuth2User 에서 반환하는 사용자 정보는 Map이므로 값 하나하나를 변환해야 한다.
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    // toEntity()
+    // User 엔티티를 생성한다.
+    // OAuthAttributes 에서 엔티티를 생성하는 시점 == 처음 가입할 때
+    // 가입할 때의 기본 권한을 GUEST로 주기 위해서 role 빌더 값에는 Role.GUEST를 설정한다.
+    public User toEntity() {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .role(Role.USER)
+                .build();
+    }
+}
+

--- a/src/main/java/com/bucwith/common/config/oauth/dto/OAuthToken.java
+++ b/src/main/java/com/bucwith/common/config/oauth/dto/OAuthToken.java
@@ -1,0 +1,20 @@
+package com.bucwith.common.config.oauth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+
+@ToString
+@NoArgsConstructor
+@Getter
+public class OAuthToken {
+    private String token;
+    private String refreshToken;
+
+    public OAuthToken(String token, String refreshToken) {
+        this.token = token;
+        this.refreshToken = refreshToken;
+    }
+}
+

--- a/src/main/java/com/bucwith/common/config/oauth/secret/Secret.java
+++ b/src/main/java/com/bucwith/common/config/oauth/secret/Secret.java
@@ -1,0 +1,7 @@
+package com.bucwith.common.config.oauth.secret;
+
+public class Secret {
+    public static String JWT_SECRET_KEY = "UwKYibQQgkW7g-*k.ap9kje-wxBHb9wdXoBT4vnt4P3sJWt-Nu";
+    public static String USER_INFO_PASSWORD_KEY = "o9pqYVC9-F8_.PEzEiw!L9F6.AYj9jcfVJ*_i.ifXYnyE68kix@Q2dL6rw*bV-rpdZYwcqZG-jPF-fw3CiJyKsfZ778ks-*jnZn";
+}
+

--- a/src/main/java/com/bucwith/common/exception/BaseException.java
+++ b/src/main/java/com/bucwith/common/exception/BaseException.java
@@ -1,0 +1,13 @@
+package com.bucwith.common.exception;
+
+import com.bucwith.common.code.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BaseException extends Exception{
+    private ApiCode status;
+}

--- a/src/main/java/com/bucwith/controller/account/AccountController.java
+++ b/src/main/java/com/bucwith/controller/account/AccountController.java
@@ -1,0 +1,45 @@
+package com.bucwith.controller.account;
+
+import com.bucwith.common.CommController;
+import com.bucwith.common.config.JwtService;
+import com.bucwith.common.exception.BaseException;
+import com.bucwith.common.exception.ExceptionController;
+import com.bucwith.dto.user.UserNameReqDto;
+import com.bucwith.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class AccountController extends CommController {
+
+    private final UserService userService;
+    private final JwtService jwtService;
+
+    /**
+     * 이름 수정
+     *  Request Data : UserNameReqDto(user name)
+     *  Response Data : success 반환
+     * @param reqDto
+     * @return
+     * @throws BaseException
+     */
+    @PutMapping("/name")
+    public ResponseEntity updateName(@Validated @RequestBody UserNameReqDto reqDto) throws BaseException {
+        String email = jwtService.getEmail();
+        userService.update(email, reqDto);
+        return SuccessReturn();
+    }
+
+}
+
+

--- a/src/main/java/com/bucwith/domain/account/Role.java
+++ b/src/main/java/com/bucwith/domain/account/Role.java
@@ -1,0 +1,16 @@
+package com.bucwith.domain.account;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST", "손님"),
+
+    USER("ROLE_USER", "일반 사용자");
+
+    private final String key;
+    private final String title;
+
+}

--- a/src/main/java/com/bucwith/domain/account/User.java
+++ b/src/main/java/com/bucwith/domain/account/User.java
@@ -1,0 +1,46 @@
+package com.bucwith.domain.account;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User {
+    @Id
+    private int userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+
+    @Builder
+    public User(String name, String email, Role role) {
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+
+    public User update(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+
+
+}

--- a/src/main/java/com/bucwith/domain/account/UserRepository.java
+++ b/src/main/java/com/bucwith/domain/account/UserRepository.java
@@ -1,0 +1,10 @@
+package com.bucwith.domain.account;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/bucwith/dto/user/UserDto.java
+++ b/src/main/java/com/bucwith/dto/user/UserDto.java
@@ -1,0 +1,20 @@
+package com.bucwith.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserDto {
+    private String email;
+    private String name;
+
+    @Builder
+    public UserDto(String email, String name) {
+        this.email = email;
+        this.name = name;
+    }
+}
+
+

--- a/src/main/java/com/bucwith/dto/user/UserNameReqDto.java
+++ b/src/main/java/com/bucwith/dto/user/UserNameReqDto.java
@@ -1,0 +1,16 @@
+package com.bucwith.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserNameReqDto {
+    private String name;
+
+    @Builder
+    public UserNameReqDto(String name){
+        this.name = name;
+    }
+}

--- a/src/main/java/com/bucwith/mapper/user/UserRequestMapper.java
+++ b/src/main/java/com/bucwith/mapper/user/UserRequestMapper.java
@@ -1,0 +1,16 @@
+package com.bucwith.mapper.user;
+
+import com.bucwith.dto.user.UserDto;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserRequestMapper {
+    public UserDto toDto(OAuth2User oAuth2User) {
+        var attributes = oAuth2User.getAttributes();
+        return UserDto.builder()
+                .email((String)attributes.get("email"))
+                .name((String)attributes.get("name"))
+                .build();
+    }
+}

--- a/src/main/java/com/bucwith/service/user/UserService.java
+++ b/src/main/java/com/bucwith/service/user/UserService.java
@@ -1,0 +1,26 @@
+package com.bucwith.service.user;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.account.UserRepository;
+import com.bucwith.dto.user.UserNameReqDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public String update(String email, UserNameReqDto reqDto) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. email=" + email));
+
+        user.update(reqDto.getName());
+
+        return email;
+    }
+}

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,10 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: 393567589007-3achadgo08t7hlnv87q6r38t2toicbot.apps.googleusercontent.com
+            #client-secret: https://www.notion.so/OAuth-d98bc25a8a0e43cda0880ce2368fd54d 참고
+            redirect-uri: http://localhost:8888/login/oauth2/code/google
+            scope: profile, email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,10 @@ spring:
   datasource:
     url: jdbc:mariadb://bucwith.cpominkx6ixa.ap-northeast-2.rds.amazonaws.com:3306/bucwith
     username: root
-    password: BUCWITH123
+    #password: https://www.notion.so/DB-8516c2ab68b9464ea5e911ec1e2b9e96 참고
     driverClassName: org.mariadb.jdbc.Driver
+  profiles:
+    include: oauth
 #    hikari:
 #      connectionTimeout: 10000 #30000ms
 #      maximumPoolSize: 20 #?? 10
@@ -14,6 +16,10 @@ spring:
 #    show-sql: false
 #    hibernate:
 #      ddl-auto: none
+
+security:
+  basic:
+    enabled: true
 
 server:
   port: 8888


### PR DESCRIPTION
- OAuth 로그인
- 이름 수정 API
**- 비밀번호 값들 비공개(db, oauth)**

### 1. 로그인
- 구글 OAuth2, Spring Security, JWT
- 서버 엔드포인트(/oauth2/authorization/google)로 요청이 온다.
- security 에서 customOAuth2UserService가 실행된다.(유저 저장)
- 성공시 jwt 토큰이 발급된다.

**Problem**
- Interceptor에서 내용을 다 가져가버려서 주석 처리하고 실행했음

**Etc**
 public repository라서 application.yml 에 있는 db 비밀번호, 
 application-oauth.yml에 있는 client oauth 비밀번호 전부 주석처리함
 전부 노션(https://www.notion.so/2acf9ca4efaf4ae6b85c1b69044f0867) 에서 확인가능

### commit 파일
**Common**
 -code
ApiCode 수정(jwt 코드 추가)
-config
 SecurityConfig 추가(SpringSecurity적용(role기반 접근 설정, session설정(jwt라 stateless), oauth2로그인 설정, jwt fillter 설정)
 JwtService 추가(jwt발급, 인증, 검증, 추출등)
- oauth
 ConfigureSuccessHandler 추가(oauth로그인 완료시 jwt 발급)
 CustomOAuth2UserService 추가(oauth요청시 로그인)
 JwtAuthenticationFilter 추가(토큰 유효성 검증)
- dto
 OAuthAttributes 추가(security로 들어오는 oauth 유저 정보)
 OAuthToken 추가(access토큰, refresh 토큰)
- secret
 Secret 추가(JWT Secret Key)
(controller, service 등등 나머지는 이름수정)
**resources**
applicaion.yml 수정(db 비밀번호 주석처리, -oauth.yml 파일 포함)
application-oauth.yml 추가(oauth 정보, secret은 주석처리)
build.gradle 수정(oauth, jwt 추가)