### PR TITLE
커뮤니티 글 작성, 조회, 댓글 작성, 조회, 좋아요 구현

### DIFF
--- a/src/main/java/com/bucwith/controller/Community/Comment/CommentController.java
+++ b/src/main/java/com/bucwith/controller/Community/Comment/CommentController.java
@@ -1,0 +1,67 @@
+package com.bucwith.controller.Community.Comment;
+
+import com.bucwith.common.CommController;
+import com.bucwith.common.config.JwtService;
+import com.bucwith.common.exception.BaseException;
+import com.bucwith.dto.community.*;
+import com.bucwith.service.Community.Comment.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/community")
+public class CommentController extends CommController {
+    private final JwtService jwtService;
+    private final CommentService commentService;
+
+    /**
+     * 댓글 등록!
+     * @param commuId
+     * @param reqDto (글번호, 댓글번호, 유저번호, 내용, 비밀여부)
+     * @return 작성된 댓글 id
+     */
+    @PostMapping("/{commuId}/comment")
+    public ResponseEntity commentSave(@PathVariable Long commuId, @Validated @RequestBody CommentSaveReqDto reqDto) throws BaseException {
+        Long commentId = commentService.commentSave(reqDto);
+        return SuccessReturn(commentId);
+    }
+
+    /**
+     * 댓글 조회 리스트!
+     * @param commuId
+     * @return (댓글 번호, 글번호, 댓글 번호, 유저이름, 내용, 비밀여부, 등록날짜)
+     */
+    @GetMapping("/{commuId}/comment")
+    public ResponseEntity findCommentAll(@PathVariable Long commuId){
+        List<CommentAllResDto> comment = commentService.findCommentAllDesc(commuId);
+        return SuccessReturn(comment);
+    }
+
+    /**
+     * 댓글 수정
+     * @param commentId
+     * @param reqDto
+     * @return 수정 댓글id
+     */
+    @PutMapping("/comment/{commentId}")
+    public ResponseEntity modifyComment(@PathVariable Long commentId, @Validated @RequestBody CommentModifyReqDto reqDto) {
+        Long modifyId = commentService.modifyComment(commentId, reqDto);
+        return SuccessReturn(modifyId);
+    }
+
+    /**
+     * 댓글 삭제
+     * @param commentId
+     * @return 삭제된 댓글 id
+     */
+    @DeleteMapping("/comment/{commentId}")
+    public ResponseEntity deleteComment(@PathVariable Long commentId){
+        commentService.deleteComment(commentId);
+        return SuccessReturn(commentId);
+    }
+}

--- a/src/main/java/com/bucwith/controller/Community/CommunityController.java
+++ b/src/main/java/com/bucwith/controller/Community/CommunityController.java
@@ -1,0 +1,103 @@
+package com.bucwith.controller.Community;
+
+import com.bucwith.common.CommController;
+import com.bucwith.common.config.JwtService;
+import com.bucwith.common.exception.BaseException;
+import com.bucwith.dto.community.CommentResDto;
+import com.bucwith.dto.community.CommentSaveReqDto;
+import com.bucwith.dto.community.CommuResDto;
+import com.bucwith.dto.community.CommuSaveReqDto;
+import com.bucwith.service.Community.CommunityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**커뮤니티 controller
+ * jwt미완+테스트의 편의성으로 인해
+ * 작성 시 유저 검증은 아직 하지 않았음
+ * jwt 완성 시 추가 예정**/
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/community")
+public class CommunityController extends CommController {
+    private final CommunityService communityService;
+    private final JwtService jwtService;
+
+    /**
+     * 게시글 저장!
+     * @param reqDto (유저id, 내용, 글타입, 카테고리 리스트, 파티원수)
+     * @return 등록한 글의 번호 반환
+     */
+    @PostMapping()
+    public ResponseEntity commuSave(@RequestBody CommuSaveReqDto reqDto) throws BaseException {
+        //Long userId=jwtService.getUserId();
+        Long commuId = communityService.commuSave(reqDto);
+        return SuccessReturn(commuId);
+    }
+
+    /**
+     * 게시글 리스트 조회!
+     * @return (글번호, 유저이름, 내용, 타입, 카테고리 배열, 파티원수, 좋아요 수, 댓글 수, 작성시간)
+     */
+    @GetMapping()
+    public ResponseEntity findCommuAll(){
+        List<CommuResDto> commu = communityService.findCommuAllDesc();
+        return SuccessReturn(commu);
+    }
+
+    /**
+     * 특정 게시글 조회!
+     * @param commuId
+     * @return (글번호, 유저이름, 내용, 타입, 카테고리 배열, 파티원수, 좋아요 수, 댓글 수, 작성시간)
+     */
+    @GetMapping("/{commuId}")
+    public ResponseEntity findCommuById(@PathVariable Long commuId){
+        CommuResDto resDto = communityService.findCommuById(commuId);
+        return SuccessReturn(resDto);
+    }
+
+    /**
+     * 댓글 등록!
+     * @param commuId
+     * @param reqDto (글번호, 댓글번호, 유저번호, 내용, 비밀여부)
+     * @return 작성된 댓글 id
+     */
+    @PostMapping("/{commuId}/comment")
+    public ResponseEntity commentSave(@PathVariable Long commuId, @RequestBody CommentSaveReqDto reqDto) throws BaseException {
+        //Long userId=jwtService.getUserId();
+
+        Long commentId = communityService.commentSave(reqDto);
+        return SuccessReturn(commentId);
+    }
+
+    /**
+     * 댓글 조회 리스트!
+     * @param commuId
+     * @return (댓글 번호, 글번호, 댓글 번호, 유저이름, 내용, 비밀여부, 등록날짜)
+     */
+    @GetMapping("/{commuId}/comment")
+    public ResponseEntity findCommentAll(@PathVariable Long commuId){
+        List<CommentResDto> comment = communityService.findCommentAllDesc(commuId);
+        return SuccessReturn(comment);
+    }
+
+    /**
+     * 게시글 좋아요!
+     * @param commuId
+     * @return 게시글 좋아요 데이터 없을 시 좋아요 등록/ 있을 시 좋아요 취소
+     * @throws BaseException
+     */
+    @PostMapping("/{commuId}/like")
+    public ResponseEntity commuLike(@PathVariable Long commuId) throws BaseException {
+        Long userId=jwtService.getUserId();
+        //Long userId = 4L;
+        communityService.commuLike(commuId,userId);
+        return SuccessReturn();
+    }
+
+
+
+
+}

--- a/src/main/java/com/bucwith/controller/Community/CommunityController.java
+++ b/src/main/java/com/bucwith/controller/Community/CommunityController.java
@@ -3,21 +3,15 @@ package com.bucwith.controller.Community;
 import com.bucwith.common.CommController;
 import com.bucwith.common.config.JwtService;
 import com.bucwith.common.exception.BaseException;
-import com.bucwith.dto.community.CommentResDto;
-import com.bucwith.dto.community.CommentSaveReqDto;
-import com.bucwith.dto.community.CommuResDto;
-import com.bucwith.dto.community.CommuSaveReqDto;
+import com.bucwith.dto.community.*;
 import com.bucwith.service.Community.CommunityService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-/**커뮤니티 controller
- * jwt미완+테스트의 편의성으로 인해
- * 작성 시 유저 검증은 아직 하지 않았음
- * jwt 완성 시 추가 예정**/
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/community")
@@ -31,57 +25,47 @@ public class CommunityController extends CommController {
      * @return 등록한 글의 번호 반환
      */
     @PostMapping()
-    public ResponseEntity commuSave(@RequestBody CommuSaveReqDto reqDto) throws BaseException {
-        //Long userId=jwtService.getUserId();
+    public ResponseEntity commuSave(@Validated @RequestBody CommuSaveReqDto reqDto) throws BaseException {
         Long commuId = communityService.commuSave(reqDto);
         return SuccessReturn(commuId);
     }
 
     /**
      * 게시글 리스트 조회!
-     * @return (글번호, 유저이름, 내용, 타입, 카테고리 배열, 파티원수, 좋아요 수, 댓글 수, 작성시간)
+     * @return (글번호, 유저이름, 내용, 타입, 카테고리 배열, 파티원수, 좋아요 수, 댓글 수, 작성시간, 좋아요 유무)
      */
     @GetMapping()
-    public ResponseEntity findCommuAll(){
-        List<CommuResDto> commu = communityService.findCommuAllDesc();
+    public ResponseEntity findCommuAll() throws BaseException {
+        Long userId=jwtService.getUserId();
+        List<CommuResDto> commu = communityService.findCommuAllDesc(userId);
         return SuccessReturn(commu);
     }
 
     /**
      * 특정 게시글 조회!
      * @param commuId
-     * @return (글번호, 유저이름, 내용, 타입, 카테고리 배열, 파티원수, 좋아요 수, 댓글 수, 작성시간)
+     * @return (글번호, 유저이름, 내용, 타입, 카테고리 배열, 파티원수, 좋아요 수, 댓글 수, 작성시간, 좋아요 유무)
      */
     @GetMapping("/{commuId}")
-    public ResponseEntity findCommuById(@PathVariable Long commuId){
-        CommuResDto resDto = communityService.findCommuById(commuId);
+    public ResponseEntity findCommuById(@PathVariable Long commuId) throws BaseException {
+        Long userId=jwtService.getUserId();
+        CommuResDto resDto = communityService.findCommuById(userId, commuId);
         return SuccessReturn(resDto);
     }
 
-    /**
-     * 댓글 등록!
-     * @param commuId
-     * @param reqDto (글번호, 댓글번호, 유저번호, 내용, 비밀여부)
-     * @return 작성된 댓글 id
-     */
-    @PostMapping("/{commuId}/comment")
-    public ResponseEntity commentSave(@PathVariable Long commuId, @RequestBody CommentSaveReqDto reqDto) throws BaseException {
-        //Long userId=jwtService.getUserId();
-
-        Long commentId = communityService.commentSave(reqDto);
-        return SuccessReturn(commentId);
+    @PutMapping("/{commuId}")
+    public ResponseEntity modifyCommu(@PathVariable Long commuId, @Validated @RequestBody CommuModifyReqDto reqDto) {
+        Long modifyId = communityService.modifyCommu(commuId, reqDto);
+        return SuccessReturn(modifyId);
     }
 
-    /**
-     * 댓글 조회 리스트!
-     * @param commuId
-     * @return (댓글 번호, 글번호, 댓글 번호, 유저이름, 내용, 비밀여부, 등록날짜)
-     */
-    @GetMapping("/{commuId}/comment")
-    public ResponseEntity findCommentAll(@PathVariable Long commuId){
-        List<CommentResDto> comment = communityService.findCommentAllDesc(commuId);
-        return SuccessReturn(comment);
+    @DeleteMapping("/{commuId}")
+    public ResponseEntity deleteCommu(@PathVariable Long commuId){
+        communityService.deleteCommu(commuId);
+        return SuccessReturn(commuId);
     }
+
+
 
     /**
      * 게시글 좋아요!

--- a/src/main/java/com/bucwith/controller/account/AccountController.java
+++ b/src/main/java/com/bucwith/controller/account/AccountController.java
@@ -34,10 +34,11 @@ public class AccountController extends CommController {
      * @throws BaseException
      */
     @PutMapping("/name")
-    public ResponseEntity updateName(@Validated @RequestBody UserNameReqDto reqDto) throws BaseException {
-        String email = jwtService.getEmail();
-        userService.update(email, reqDto);
-        return SuccessReturn();
+    public ResponseEntity updateName(@Validated @RequestBody UserNameReqDto reqDto ) throws BaseException {
+        Long userId = jwtService.getUserId();
+        userService.update(userId, reqDto);
+        return SuccessReturn(reqDto);
+
     }
 
 }

--- a/src/main/java/com/bucwith/domain/account/User.java
+++ b/src/main/java/com/bucwith/domain/account/User.java
@@ -3,8 +3,10 @@ package com.bucwith.domain.account;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 
 @Getter
@@ -12,18 +14,22 @@ import javax.persistence.*;
 @Entity
 public class User {
     @Id
-    private int userId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
 
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    @CreationTimestamp
+    private LocalDateTime registDate;
 
 
     @Builder

--- a/src/main/java/com/bucwith/domain/community/Category.java
+++ b/src/main/java/com/bucwith/domain/community/Category.java
@@ -1,0 +1,50 @@
+package com.bucwith.domain.community;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum Category {
+    CC001("CC001","영화"), // 벅윗 파티원 모집
+
+    CC002("CC002","여행"), //질문있어요
+
+    CC003("CC003","대학합격"), // 추천해주세요
+    CC004("CC004","미용/뷰티"), // 추천해주세요
+    CC005("CC005","연애"), // 추천해주세요
+    CC006("CC006","자격증"), // 추천해주세요
+    CC007("CC007","공부"), // 추천해주세요
+    CC008("CC008","다이어트"), // 추천해주세요
+    CC009("CC009","음식"), // 추천해주세요
+    CC010("CC010","동물"), // 추천해주세요
+    CC011("CC011","게임"), // 벅윗 파티원 모집
+
+    CC012("CC012","IT"), //질문있어요
+
+    CC013("CC013","돈"), // 추천해주세요
+    CC014("CC014","건강"), // 추천해주세요
+    CC015("CC015","운동"), // 추천해주세요
+    CC016("CC016","휴식/힐링"), // 추천해주세요
+    CC017("CC017","외국어"), // 추천해주세요
+    CC018("CC018","심리/마음"), // 추천해주세요
+    CC019("CC019","운전"), // 추천해주세요
+    CC020("CC020","취미"), // 추천해주세요
+    CC021("CC021","기타"); // 추천해주세요
+
+    private String code;
+    private String desc;
+
+    Category(String code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    // @RequestBody ENUM Parsing
+    @JsonCreator
+    public static Category from(String s) {
+        return Category.valueOf(s);
+    }
+}
+

--- a/src/main/java/com/bucwith/domain/community/Clike.java
+++ b/src/main/java/com/bucwith/domain/community/Clike.java
@@ -1,0 +1,31 @@
+package com.bucwith.domain.community;
+
+import com.bucwith.domain.account.User;
+import lombok.*;
+
+import javax.persistence.*;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Clike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long likeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="commuId")
+    private Community community;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="userId")
+    private User user;
+
+    @Builder
+    public Clike(Community community, User user) {
+        this.community = community;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/bucwith/domain/community/Comment.java
+++ b/src/main/java/com/bucwith/domain/community/Comment.java
@@ -21,7 +21,7 @@ public class Comment {
     @JoinColumn(name="commuId")
     private Community community;
 
-    private int replyId;
+    private Long replyId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="userId")
@@ -35,11 +35,16 @@ public class Comment {
     private LocalDateTime registDate;
 
     @Builder
-    public Comment(Community community, int replyId, User user, String content, Boolean secret) {
+    public Comment(Community community, Long replyId, User user, String content, Boolean secret) {
         this.community = community;
         this.replyId = replyId;
         this.user = user;
         this.secret = secret;
         this.content = content;
+    }
+
+    public void modify(String content, Boolean secret){
+        this.content = content;
+        this.secret = secret;
     }
 }

--- a/src/main/java/com/bucwith/domain/community/Comment.java
+++ b/src/main/java/com/bucwith/domain/community/Comment.java
@@ -1,0 +1,45 @@
+package com.bucwith.domain.community;
+
+import com.bucwith.domain.account.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long comId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="commuId")
+    private Community community;
+
+    private int replyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="userId")
+    private User user;
+
+    private String content;
+
+    private Boolean secret;
+
+    @CreationTimestamp
+    private LocalDateTime registDate;
+
+    @Builder
+    public Comment(Community community, int replyId, User user, String content, Boolean secret) {
+        this.community = community;
+        this.replyId = replyId;
+        this.user = user;
+        this.secret = secret;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/bucwith/domain/community/CommuCate.java
+++ b/src/main/java/com/bucwith/domain/community/CommuCate.java
@@ -1,0 +1,29 @@
+package com.bucwith.domain.community;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class CommuCate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ccId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="commuId")
+    private Community community;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+
+    @Builder
+    public CommuCate(Community community, Category category) {
+        this.community = community;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/bucwith/domain/community/CommuType.java
+++ b/src/main/java/com/bucwith/domain/community/CommuType.java
@@ -1,0 +1,29 @@
+package com.bucwith.domain.community;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum CommuType {
+    CT001("CT001","벅윗 파티원 모집"), // 벅윗 파티원 모집
+
+    CT002("CT002","질문있어요"), //질문있어요
+
+    CT003("CT003","추천해주세요"); // 추천해주세요
+
+    private String code;
+    private String desc;
+
+    CommuType(String code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    // @RequestBody ENUM Parsing
+    @JsonCreator
+    public static CommuType from(String s) {
+        return CommuType.valueOf(s);
+    }
+}

--- a/src/main/java/com/bucwith/domain/community/Community.java
+++ b/src/main/java/com/bucwith/domain/community/Community.java
@@ -32,6 +32,9 @@ public class Community {
 
     private int party;
 
+    private int likeCnt;
+    private int commentCnt;
+
     @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE)
     @OrderBy("comId asc")
     private List<Comment> comments = new ArrayList<Comment>();
@@ -40,10 +43,21 @@ public class Community {
     @OrderBy("likeId asc")
     private List<Clike> likes = new ArrayList<Clike>();
 
+    @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE)
+    @OrderBy("ccId asc")
+    private List<CommuCate> commuCates = new ArrayList<CommuCate>();
+
+
 
     @Builder
     public Community(User user, String content, CommuType type, int party) {
         this.user = user;
+        this.content = content;
+        this.type = type;
+        this.party = party;
+    }
+
+    public void modify(String content, CommuType type, int party){
         this.content = content;
         this.type = type;
         this.party = party;

--- a/src/main/java/com/bucwith/domain/community/Community.java
+++ b/src/main/java/com/bucwith/domain/community/Community.java
@@ -1,0 +1,55 @@
+package com.bucwith.domain.community;
+
+import com.bucwith.domain.account.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Community {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commuId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="userId")
+    private User user;
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private CommuType type;
+
+    @CreationTimestamp
+    private LocalDateTime registDate;
+
+    private int party;
+
+    @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE)
+    @OrderBy("comId asc")
+    private List<Comment> comments = new ArrayList<Comment>();
+
+    @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE)
+    @OrderBy("likeId asc")
+    private List<Clike> likes = new ArrayList<Clike>();
+
+
+    @Builder
+    public Community(User user, String content, CommuType type, int party) {
+        this.user = user;
+        this.content = content;
+        this.type = type;
+        this.party = party;
+    }
+
+    }
+
+
+

--- a/src/main/java/com/bucwith/dto/community/CategorySaveReqDto.java
+++ b/src/main/java/com/bucwith/dto/community/CategorySaveReqDto.java
@@ -1,0 +1,24 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.community.Category;
+import com.bucwith.domain.community.Community;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategorySaveReqDto {
+
+    private Long commuId;
+
+    private Category category;
+
+    @Builder
+    public CategorySaveReqDto(Long commuId, Category category){
+        this.commuId = commuId;
+        this.category = category;
+    }
+
+
+}

--- a/src/main/java/com/bucwith/dto/community/CommentAllResDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommentAllResDto.java
@@ -1,33 +1,32 @@
 package com.bucwith.dto.community;
 
-import com.bucwith.domain.account.User;
 import com.bucwith.domain.community.Comment;
-import com.bucwith.domain.community.Community;
 import lombok.Getter;
 
-import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-
-public class CommentResDto {
+public class CommentAllResDto {
     private Long commentId;
+    private Long commuId;
     private Long replyId;
     private Long userId;
     private String userName;
     private String content;
     private Boolean secret;
     private LocalDateTime registDate;
+    private List<CommentResDto> replys;
 
-    public CommentResDto(Comment entity){
+    public CommentAllResDto(Comment entity, List<CommentResDto> replys){
         this.commentId = entity.getComId();
+        this.commuId = entity.getCommunity().getCommuId();
         this.replyId = entity.getReplyId();
         this.userId = entity.getUser().getUserId();
         this.userName = entity.getUser().getName();
         this.content = entity.getContent();
         this.secret = entity.getSecret();
         this.registDate = entity.getRegistDate();
+        this.replys = replys;
     }
-
 }

--- a/src/main/java/com/bucwith/dto/community/CommentModifyReqDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommentModifyReqDto.java
@@ -1,0 +1,20 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Community;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentModifyReqDto {
+    private String content;
+    private Boolean secret;
+
+    @Builder
+    public CommentModifyReqDto(String content, Boolean secret){
+        this.content = content;
+        this.secret = secret;
+    }
+}

--- a/src/main/java/com/bucwith/dto/community/CommentResDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommentResDto.java
@@ -1,0 +1,33 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Comment;
+import com.bucwith.domain.community.Community;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+@Getter
+
+public class CommentResDto {
+    private Long comId;
+    private Long commuId;
+    private int replyId;
+    private String userName;
+    private String content;
+    private Boolean secret;
+    private LocalDateTime registDate;
+
+
+    public CommentResDto(Comment entity){
+        this.comId = entity.getComId();
+        this.commuId = entity.getCommunity().getCommuId();
+        this.replyId = entity.getReplyId();
+        this.userName = entity.getUser().getName();
+        this.content = entity.getContent();
+        this.secret = entity.getSecret();
+        this.registDate = entity.getRegistDate();
+    }
+
+}

--- a/src/main/java/com/bucwith/dto/community/CommentSaveReqDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommentSaveReqDto.java
@@ -1,0 +1,40 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Comment;
+import com.bucwith.domain.community.Community;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class CommentSaveReqDto {
+    private Community community;
+    private int replyId;
+    private User user;
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+    private Boolean secret;
+
+    @Builder
+    public CommentSaveReqDto(Community community, int replyId, User user, String content, Boolean secret){
+        this.community = community;
+        this.replyId = replyId;
+        this.user = user;
+        this.content = content;
+        this.secret = secret;
+    }
+
+    public Comment toEntity(){
+        return Comment.builder()
+                .community(community)
+                .replyId(replyId)
+                .user(user)
+                .content(content)
+                .secret(secret)
+                .build();
+    }
+}

--- a/src/main/java/com/bucwith/dto/community/CommentSaveReqDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommentSaveReqDto.java
@@ -13,14 +13,14 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class CommentSaveReqDto {
     private Community community;
-    private int replyId;
+    private Long replyId;
     private User user;
     @NotBlank(message = "내용을 입력해주세요")
     private String content;
     private Boolean secret;
 
     @Builder
-    public CommentSaveReqDto(Community community, int replyId, User user, String content, Boolean secret){
+    public CommentSaveReqDto(Community community, Long replyId, User user, String content, Boolean secret){
         this.community = community;
         this.replyId = replyId;
         this.user = user;

--- a/src/main/java/com/bucwith/dto/community/CommuModifyReqDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommuModifyReqDto.java
@@ -1,0 +1,29 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Category;
+import com.bucwith.domain.community.CommuType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CommuModifyReqDto {
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+    private CommuType type;
+    private List<Category> category;
+    private int party;
+
+    @Builder
+    public CommuModifyReqDto(String content, CommuType type, List<Category> category, int party){
+        this.content = content;
+        this.type = type;
+        this.category = category;
+        this.party = party;
+    }
+}

--- a/src/main/java/com/bucwith/dto/community/CommuResDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommuResDto.java
@@ -1,0 +1,37 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Category;
+import com.bucwith.domain.community.CommuType;
+import com.bucwith.domain.community.Community;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class CommuResDto {
+    private Long commuId;
+    private String userName;
+    private String content;
+    private CommuType type;
+    private List<Category> categoryList;
+    private int party;
+    private Long likeCnt;
+    private Long commentCnt;
+    private LocalDateTime registDate;
+
+    public CommuResDto(Community entity, List<Category> categoryList, Long likeCnt, Long commentCnt){
+        this.commuId = entity.getCommuId();
+        this.userName = entity.getUser().getName();
+        this.content = entity.getContent();
+        this.type = entity.getType();
+        this.party = entity.getParty();
+        this.registDate = entity.getRegistDate();
+        this.categoryList = categoryList;
+        this.likeCnt = likeCnt;
+        this.commentCnt = commentCnt;
+
+    }
+
+}

--- a/src/main/java/com/bucwith/dto/community/CommuResDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommuResDto.java
@@ -19,9 +19,10 @@ public class CommuResDto {
     private int party;
     private Long likeCnt;
     private Long commentCnt;
+    private Boolean isLike;
     private LocalDateTime registDate;
 
-    public CommuResDto(Community entity, List<Category> categoryList, Long likeCnt, Long commentCnt){
+    public CommuResDto(Community entity, List<Category> categoryList, Long likeCnt, Long commentCnt, Boolean isLike){
         this.commuId = entity.getCommuId();
         this.userName = entity.getUser().getName();
         this.content = entity.getContent();
@@ -31,6 +32,7 @@ public class CommuResDto {
         this.categoryList = categoryList;
         this.likeCnt = likeCnt;
         this.commentCnt = commentCnt;
+        this.isLike = isLike;
 
     }
 

--- a/src/main/java/com/bucwith/dto/community/CommuSaveReqDto.java
+++ b/src/main/java/com/bucwith/dto/community/CommuSaveReqDto.java
@@ -1,0 +1,44 @@
+package com.bucwith.dto.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Category;
+import com.bucwith.domain.community.CommuType;
+import com.bucwith.domain.community.Community;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CommuSaveReqDto {
+
+    private User user;
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+    private CommuType type;
+    private List<Category> category;
+    private int party;
+
+    @Builder
+    public CommuSaveReqDto(User user, String content, CommuType type, List<Category> category, int party){
+        this.user = user;
+        this.content = content;
+        this.type = type;
+        this.category = category;
+        this.party = party;
+    }
+
+
+    public Community toEntity(){
+        return Community.builder()
+                .user(user)
+                .content(content)
+                .type(type)
+                .party(party)
+                .build();
+    }
+
+}

--- a/src/main/java/com/bucwith/dto/user/UserDto.java
+++ b/src/main/java/com/bucwith/dto/user/UserDto.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class UserDto {
+    private int userId;
     private String email;
     private String name;
 
     @Builder
-    public UserDto(String email, String name) {
+    public UserDto(int userId, String email, String name) {
+        this.userId = userId;
         this.email = email;
         this.name = name;
     }

--- a/src/main/java/com/bucwith/repository/community/ClikeRepository.java
+++ b/src/main/java/com/bucwith/repository/community/ClikeRepository.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 public interface ClikeRepository extends JpaRepository<Clike, Long> {
     Optional<Clike> findByCommunityAndUser(Community community, User user);
 
+    Boolean existsByCommunityAndUser(Community community, User user);
+
     @Query("SELECT COUNT(l) FROM Clike l WHERE l.community.commuId = :commuId")
     Long CountByCommunity(@Param("commuId") Long commuId);
 

--- a/src/main/java/com/bucwith/repository/community/ClikeRepository.java
+++ b/src/main/java/com/bucwith/repository/community/ClikeRepository.java
@@ -1,0 +1,20 @@
+package com.bucwith.repository.community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.domain.community.Community;
+import com.bucwith.domain.community.Clike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ClikeRepository extends JpaRepository<Clike, Long> {
+    Optional<Clike> findByCommunityAndUser(Community community, User user);
+
+    @Query("SELECT COUNT(l) FROM Clike l WHERE l.community.commuId = :commuId")
+    Long CountByCommunity(@Param("commuId") Long commuId);
+
+}

--- a/src/main/java/com/bucwith/repository/community/CommentRepository.java
+++ b/src/main/java/com/bucwith/repository/community/CommentRepository.java
@@ -12,8 +12,14 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c ORDER BY c.comId DESC")
-    List<Comment> findAllDesc();
+    @Query("SELECT c FROM Comment c WHERE c.community.commuId = :commuId AND c.replyId IS NULL ORDER BY c.comId ASC")
+    List<Comment> findCommentDesc(@Param("commuId") Long commuId);
+
+    @Query("SELECT c FROM Comment c WHERE c.community.commuId = :commuId AND c.replyId = :replyId ORDER BY c.comId ASC")
+    List<Comment> findReplyDesc(@Param("commuId") Long commuId, @Param("replyId") Long replyId);
+
+    @Query("SELECT c FROM Comment c WHERE c.community.commuId = :commuId ORDER BY c.comId ASC")
+    List<Comment> findAllDesc(@Param("commuId") Long commuId);
 
     @Query("SELECT COUNT( c ) FROM Comment c WHERE c.community.commuId = :commuId")
     Long CountByCommunity(@Param("commuId") Long commuId);

--- a/src/main/java/com/bucwith/repository/community/CommentRepository.java
+++ b/src/main/java/com/bucwith/repository/community/CommentRepository.java
@@ -1,0 +1,22 @@
+package com.bucwith.repository.community;
+
+import com.bucwith.domain.community.Comment;
+import com.bucwith.domain.community.Community;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c ORDER BY c.comId DESC")
+    List<Comment> findAllDesc();
+
+    @Query("SELECT COUNT( c ) FROM Comment c WHERE c.community.commuId = :commuId")
+    Long CountByCommunity(@Param("commuId") Long commuId);
+
+
+}

--- a/src/main/java/com/bucwith/repository/community/CommuCateRepository.java
+++ b/src/main/java/com/bucwith/repository/community/CommuCateRepository.java
@@ -1,0 +1,11 @@
+package com.bucwith.repository.community;
+
+import com.bucwith.domain.community.CommuCate;
+import com.bucwith.domain.community.Community;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommuCateRepository extends JpaRepository<CommuCate, Long> {
+    List<CommuCate> findByCommunity(Community community);
+}

--- a/src/main/java/com/bucwith/repository/community/CommunityRepository.java
+++ b/src/main/java/com/bucwith/repository/community/CommunityRepository.java
@@ -1,0 +1,12 @@
+package com.bucwith.repository.community;
+
+import com.bucwith.domain.community.Community;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CommunityRepository extends JpaRepository<Community, Long> {
+    @Query("SELECT c FROM Community c ORDER BY c.commuId DESC")
+    List<Community> findAllDesc();
+}

--- a/src/main/java/com/bucwith/repository/user/UserRepository.java
+++ b/src/main/java/com/bucwith/repository/user/UserRepository.java
@@ -1,10 +1,11 @@
-package com.bucwith.domain.account;
+package com.bucwith.repository.user;
 
+import com.bucwith.domain.account.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/bucwith/service/Community/Comment/CommentService.java
+++ b/src/main/java/com/bucwith/service/Community/Comment/CommentService.java
@@ -1,0 +1,64 @@
+package com.bucwith.service.Community.Comment;
+
+import com.bucwith.domain.community.Category;
+import com.bucwith.domain.community.Comment;
+import com.bucwith.domain.community.CommuCate;
+import com.bucwith.domain.community.Community;
+import com.bucwith.dto.community.*;
+import com.bucwith.repository.community.CommentRepository;
+import com.bucwith.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+
+    @Transactional
+    public Long commentSave(CommentSaveReqDto reqDto){
+        Long commentId = commentRepository.save(reqDto.toEntity()).getComId();
+
+        return commentId;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentAllResDto> findCommentAllDesc(Long commuId){
+        List<Comment> comments = commentRepository.findCommentDesc(commuId);
+
+        List<CommentAllResDto> commentAll = new ArrayList<>();
+
+        for (Comment comment : comments){
+            List<CommentResDto> commentResDtos = commentRepository.findReplyDesc(commuId, comment.getComId()).stream()
+                    .map(CommentResDto::new)
+                    .collect(Collectors.toList());
+            CommentAllResDto resDto = new CommentAllResDto(comment, commentResDtos);
+            commentAll.add(resDto);
+        }
+
+        return commentAll;
+    }
+
+    @Transactional
+    public Long modifyComment(Long commentId, CommentModifyReqDto reqDto){
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 없습니다. id=" + commentId));
+        comment.modify(reqDto.getContent(), reqDto.getSecret());
+
+        return commentId;
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId){
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 없습니다. id=" + commentId));
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/bucwith/service/Community/CommunityService.java
+++ b/src/main/java/com/bucwith/service/Community/CommunityService.java
@@ -1,0 +1,161 @@
+package com.bucwith.service.Community;
+
+import com.bucwith.domain.account.User;
+import com.bucwith.repository.user.UserRepository;
+import com.bucwith.domain.community.Category;
+import com.bucwith.domain.community.CommuCate;
+import com.bucwith.domain.community.Community;
+import com.bucwith.domain.community.Clike;
+import com.bucwith.dto.community.*;
+import com.bucwith.repository.community.CommentRepository;
+import com.bucwith.repository.community.CommuCateRepository;
+import com.bucwith.repository.community.CommunityRepository;
+import com.bucwith.repository.community.ClikeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CommunityService {
+    private final CommunityRepository communityRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final ClikeRepository clikeRepository;
+    private final CommuCateRepository commuCateRepository;
+
+    /**게시글 저장**/
+    //@Transactional
+    public Long commuSave(CommuSaveReqDto reqDto){
+        User user  = userRepository.findById(reqDto.getUser().getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. id=" + reqDto.getUser().getUserId()));
+
+        /**게시글 저장**/
+        Long commuId = communityRepository.save(reqDto.toEntity()).getCommuId();
+
+        if(!CollectionUtils.isEmpty(reqDto.getCategory())){
+            /**카테고리 저장**/
+            SaveCategory(commuId, reqDto.getCategory());
+        }
+        return commuId;
+    }
+
+    /**카테고리 저장**/
+    public void SaveCategory(Long commuId,List<Category> categoryList){
+        Community entity  = communityRepository.findById(commuId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. id=" + commuId));
+
+        for(Category category : categoryList){
+            CommuCate commuCate =
+                    CommuCate.builder()
+                            .community(entity)
+                            .category(category)
+                            .build();
+            commuCateRepository.save(commuCate);
+        }
+    }
+
+    /**게시글 조회**/
+    @Transactional(readOnly = true)
+    public CommuResDto findCommuById(Long commuId){
+        /**글 불러오기**/
+        Community entity  = communityRepository.findById(commuId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. id=" + commuId));
+
+        /**카테고리 불러오기**/
+        List<CommuCate> categorys = commuCateRepository.findByCommunity(entity);
+        List<Category> categoryList = new ArrayList<>();
+        for (CommuCate commuCate: categorys){
+            categoryList.add(commuCate.getCategory());
+        }
+
+        /**좋아요 개수**/
+        Long LikeCnt = clikeRepository.CountByCommunity(entity.getCommuId());
+
+        /**댓글 개수**/
+        Long CommCnt = commentRepository.CountByCommunity(entity.getCommuId());
+
+        return new CommuResDto(entity, categoryList, LikeCnt, CommCnt);
+    }
+
+    /**전체 글 조회**/
+    @Transactional(readOnly = true)
+    public List<CommuResDto> findCommuAllDesc(){
+        /**커뮤니티 리스트 전체 조회**/
+        List<Community> communities = communityRepository.findAllDesc();
+
+
+        List<CommuResDto> commuList = new ArrayList<>();
+
+        for (Community community : communities){
+            /**좋아요 개수**/
+            Long likeCnt = clikeRepository.CountByCommunity(community.getCommuId());
+            /**댓글 개수**/
+            Long commCnt = commentRepository.CountByCommunity(community.getCommuId());
+            /**커뮤니티 카테고리 배열 생성**/
+            List<CommuCate> categorys = commuCateRepository.findByCommunity(community);
+            List<Category> categoryList = new ArrayList<>();
+            for (CommuCate commuCate: categorys){
+                categoryList.add(commuCate.getCategory());
+            }
+            /**보여줄 커뮤니티 객체 생성**/
+            CommuResDto resDto = new CommuResDto(community, categoryList, likeCnt, commCnt);
+            commuList.add(resDto);
+        }
+
+        return commuList;
+    }
+
+    /**댓글 저장**/
+    @Transactional
+    public Long commentSave(CommentSaveReqDto reqDto){
+
+        Long commentId = commentRepository.save(reqDto.toEntity()).getComId();
+
+        return commentId;
+    }
+
+    /**댓글 조회**/
+    @Transactional(readOnly = true)
+    public List<CommentResDto> findCommentAllDesc(Long commuId){
+        return commentRepository.findAllDesc().stream()
+                .map(CommentResDto::new)
+                .collect(Collectors.toList());
+    }
+
+    /**좋아요**/
+    @Transactional
+    public void commuLike(Long commuId, Long userId){
+        /**커뮤니티, 작성자 확인**/
+        Community community = communityRepository.findById(commuId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 글이 없습니다. id=" + commuId));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. id=" + userId));
+
+        /**좋아요 여부 확인**/
+        Optional<Clike> isLike = clikeRepository.findByCommunityAndUser(community, user);
+
+        isLike.ifPresentOrElse(
+                /**좋아요가 있다면 좋아요 삭제**/
+                clike -> {
+                    clikeRepository.delete(clike);
+                },
+                /**좋아요가 저장안되었다면 좋아요 등록**/
+                () -> {
+                    Clike like = Clike.builder()
+                            .community(community)
+                            .user(user)
+                            .build();
+                    clikeRepository.save(like);
+                }
+        );
+    }
+}

--- a/src/main/java/com/bucwith/service/user/UserService.java
+++ b/src/main/java/com/bucwith/service/user/UserService.java
@@ -1,7 +1,7 @@
 package com.bucwith.service.user;
 
 import com.bucwith.domain.account.User;
-import com.bucwith.domain.account.UserRepository;
+import com.bucwith.repository.user.UserRepository;
 import com.bucwith.dto.user.UserNameReqDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,12 +15,12 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public String update(String email, UserNameReqDto reqDto) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. email=" + email));
+    public Long update(Long id, UserNameReqDto reqDto) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다. email=" + id));
 
         user.update(reqDto.getName());
 
-        return email;
+        return id;
     }
 }


### PR DESCRIPTION
1. 개발
- 커뮤니티 글 작성, 조회API
- 댓글 작성, 조회 API
- 좋아요 API

2. 수정
- userId 타입 int->long 

(딱히 설명이 필요없는 로직이기 때문에 추가설명x)

AccountController, User, UserService, JwtService, UserRepository Commit파일의 경우 
id 타입을 int-> long으로 수정했기 때문에 변경에 포함(작성, 조회에서 유저가 포함되기 때문에 이번 커밋에 포함시켰음) =볼 필요 없음
(+모든 엔터티(user포함) id int->long으로 수정)

+(해야할 것>수정, 삭제, 글 필터)